### PR TITLE
Fix the linting workflow.

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,5 +1,5 @@
 name: Continuous Integration
-on: [push, pull_request]
+on: push
 
 jobs:
   lint:

--- a/.github/workflows/linting-workflow.yml
+++ b/.github/workflows/linting-workflow.yml
@@ -1,13 +1,18 @@
 name: Linting
-on: [push, pull_request]
+on: push
 
 jobs:
   lint:
     name: Linting
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+
       - name: Checkout
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v2
 
       - name: Run 'make lint'
         run: make lint

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -12,4 +12,4 @@ if ! "$GOBIN/golangci-lint" --version 2>/dev/null | grep -q "$GOLANGCILINT_VERSI
         | sh -s -- -b "$GOBIN" "v${GOLANGCILINT_VERSION}"
 fi
 
-"$GOBIN/golangci-lint" run
+"$GOBIN/golangci-lint" run --timeout 5m


### PR DESCRIPTION
Linting failed with 'golangci-lint' running into a timeout. This was caused by Go modules being downloaded as part of the linting. This is resolved by downloading all modules prior to linting.