### PR TITLE
Cache Go modules between CI builds

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -14,5 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Cache downloaded modules
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Run 'make test'
         run: make test

--- a/.github/workflows/linting-workflow.yml
+++ b/.github/workflows/linting-workflow.yml
@@ -14,5 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Cache downloaded modules
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Run 'make lint'
         run: make lint


### PR DESCRIPTION
Uses the `cache` action as described in https://github.com/actions/cache/blob/master/examples.md#go---modules