### PR TITLE
Add a configuration for 'pre-commit'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# Git hooks for test-tools. Install with
+# pre-commit install -t pre-commit -t commit-msg
+repos:
+  - repo: local
+    hooks:
+      - id: golangci-lint
+        name: golangci-lint
+        description: Check that source code is linted
+        entry: make lint
+        language: system
+        stages: [commit]
+  - repo: local
+    hooks:
+      - id: signed-off-commits
+        name: signed-off-commits
+        description: Check that commit messages include a 'Signed-off-by' line
+        entry: ./scripts/check-commit-sign-off.sh
+        language: script
+        stages: [commit-msg]

--- a/scripts/check-commit-sign-off.sh
+++ b/scripts/check-commit-sign-off.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+file="$1"
+
+signedoff_regex='^Signed-off-by: '
+
+if [ "$(grep -c "$signedoff_regex" "$file")" != "1" ]; then
+	printf >&2 "Signed-off-by line is missing.\n"
+	exit 1
+fi


### PR DESCRIPTION
When using 'pre-commit', code is checked to be linted before committing and commit messages are checked for DCO.