### PR TITLE
Introduce a debug package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/kudobuilder/kudo v0.11.1
+	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.5.1
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -13,6 +13,8 @@ type Client struct {
 	Kubernetes kubernetes.Interface
 	Kudo       kudo.Interface
 	Config     rest.Config
+	// may be empty in the "in cluster" case
+	KubeConfigPath string
 }
 
 // NewForConfig creates a Client using a kubeconfig path.
@@ -33,9 +35,10 @@ func NewForConfig(kubeconfigPath string) (Client, error) {
 	}
 
 	return Client{
-		Kubernetes: kubernetesClient,
-		Kudo:       kudoClient,
-		Config:     *config,
+		Kubernetes:     kubernetesClient,
+		Kudo:           kudoClient,
+		Config:         *config,
+		KubeConfigPath: kubeconfigPath,
 	}, nil
 }
 

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -1,0 +1,146 @@
+package debug
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/afero"
+)
+
+const (
+	testArtifactsDirectoryVarName = "TEST_ARTIFACTS_DIRECTORY"
+)
+
+var (
+	// globals for overriding in unit tests
+	artifactsDirectoryBase = os.Getenv(testArtifactsDirectoryVarName) // nolint:gochecknoglobals
+	execCommand            = exec.Command                             // nolint:gochecknoglobals
+	now                    = time.Now                                 // nolint:gochecknoglobals
+)
+
+// CollectArtifacts collects useful debugging artifacts from a given namespace.
+// Should typically be called if CurrentGinkgoTestDescription().Failed, like this:
+//   debug.CollectArtifacts(afero.NewOsFs(), GinkgoWriter, TestNamespace, KubeConfigPath, KubectlPath)
+func CollectArtifacts(fs afero.Fs, writer io.Writer, namespace, kubeConfigPath, kubectlPath string) {
+	err := collectNamespacedResources(fs, writer, namespace, kubeConfigPath, kubectlPath)
+	if err != nil {
+		_, _ = fmt.Fprintf(writer, "collection of resources for debugging failed: %v\n", err)
+	}
+}
+
+func collectNamespacedResources(fs afero.Fs, writer io.Writer, namespace, kubeConfigPath, kubectlPath string) error {
+	if artifactsDirectoryBase == "" {
+		return fmt.Errorf("$%s not set", testArtifactsDirectoryVarName)
+	}
+
+	_, _ = fmt.Fprintf(writer, "collecting namespaced resources for debugging...\n")
+
+	cmd := execCommand(
+		kubectlPath,
+		"--kubeconfig",
+		kubeConfigPath,
+		"api-resources",
+		"--verbs=list",
+		"--namespaced=true",
+		"-o",
+		"name")
+	cmd.Stderr = writer
+
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("fetching API resource types failed: %v", err)
+	}
+
+	artifactsDirectory := path.Join(artifactsDirectoryBase, fmt.Sprintf("%s-%s", namespace, now().Format(time.RFC3339)))
+
+	err = fs.MkdirAll(artifactsDirectory, 0777)
+	if err != nil {
+		return fmt.Errorf("creating %q failed: %v", artifactsDirectory, err)
+	}
+
+	resources := strings.Split(string(output), "\n")
+	groupedResources := make(map[string][]string)
+
+	for _, resources := range resources {
+		if resources == "" {
+			continue
+		}
+
+		resourcesAndGroup := strings.SplitN(resources, ".", 2)
+
+		var group string
+
+		if len(resourcesAndGroup) == 2 {
+			group = resourcesAndGroup[1]
+		}
+
+		groupedResources[group] = append(groupedResources[group], resources)
+	}
+
+	var wg sync.WaitGroup
+
+	for group, resourcesSlice := range groupedResources {
+		sort.Strings(resourcesSlice)
+
+		resources := strings.Join(resourcesSlice, ",")
+
+		var fileName string
+
+		if group == "" {
+			fileName = "resources.yaml"
+		} else {
+			fileName = fmt.Sprintf("resources-%s.yaml", group)
+		}
+
+		wg.Add(1)
+
+		go collectResources(fs, writer, &wg, namespace, fileName, resources,
+			artifactsDirectory, kubectlPath, kubeConfigPath)
+	}
+
+	wg.Wait()
+
+	return nil
+}
+
+func collectResources(fs afero.Fs, writer io.Writer, wg *sync.WaitGroup, namespace, fileName, resourcesNames,
+	directoryName, kubectlPath, kubeConfigPath string) {
+	defer wg.Done()
+
+	outPath := path.Join(directoryName, fileName)
+
+	output, err := fs.Create(outPath)
+	if err != nil {
+		_, _ = fmt.Fprintf(writer, "creating %q failed: %v\n", outPath, err)
+		return
+	}
+
+	cmd := execCommand(kubectlPath, "--kubeconfig", kubeConfigPath, "get", resourcesNames,
+		"--namespace", namespace, "--ignore-not-found", "-o", "yaml")
+	cmd.Stdout = output
+	cmd.Stderr = writer
+
+	err = cmd.Run()
+	if err != nil {
+		_, _ = fmt.Fprintf(writer, "fetching %s failed: %v\n", resourcesNames, err)
+	}
+
+	empty, err := afero.IsEmpty(fs, outPath)
+	if err != nil {
+		_, _ = fmt.Fprintf(writer, "checking %s for emptiness failed: %v\n", outPath, err)
+	}
+
+	if empty {
+		err = fs.Remove(outPath)
+		if err != nil {
+			_, _ = fmt.Fprintf(writer, "removing empty %s failed: %v\n", outPath, err)
+		}
+	}
+}

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -42,15 +42,18 @@ func CollectArtifacts(client client.Client, fs afero.Fs, writer io.Writer, names
 	}.collectArtifacts(client, fs, writer, namespace, kubectlPath)
 }
 
-func (d debugDeps) collectArtifacts(client client.Client, fs afero.Fs, writer io.Writer, namespace, kubectlPath string) error {
+func (d debugDeps) collectArtifacts(
+	client client.Client, fs afero.Fs, writer io.Writer, namespace, kubectlPath string) error {
 	err := d.collectNamespacedResources(client, fs, writer, namespace, kubectlPath)
 	if err != nil {
 		_, _ = fmt.Fprintf(writer, "collection of resources for debugging failed: %v\n", err)
 	}
+
 	return err
 }
 
-func (d debugDeps) collectNamespacedResources(client client.Client, fs afero.Fs, writer io.Writer, namespace, kubectlPath string) error {
+func (d debugDeps) collectNamespacedResources(
+	client client.Client, fs afero.Fs, writer io.Writer, namespace, kubectlPath string) error {
 	if d.artifactsDirectoryBase == "" {
 		return fmt.Errorf("$%s not set", testArtifactsDirectoryVarName)
 	}
@@ -125,7 +128,15 @@ func (d debugDeps) collectNamespacedResources(client client.Client, fs afero.Fs,
 	return nil
 }
 
-func (d debugDeps) collectResources(client client.Client, fs afero.Fs, writer io.Writer, wg *sync.WaitGroup, namespace, fileName, resourcesNames, directoryName, kubectlPath string) {
+func (d debugDeps) collectResources(
+	client client.Client,
+	fs afero.Fs,
+	writer io.Writer,
+	wg *sync.WaitGroup,
+	namespace, fileName,
+	resourcesNames,
+	directoryName,
+	kubectlPath string) {
 	defer wg.Done()
 
 	outPath := path.Join(directoryName, fileName)

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -43,7 +43,8 @@ func (d debugDeps) collectArtifacts(fs afero.Fs, writer io.Writer, namespace, ku
 	}
 }
 
-func (d debugDeps) collectNamespacedResources(fs afero.Fs, writer io.Writer, namespace, kubeConfigPath, kubectlPath string) error {
+func (d debugDeps) collectNamespacedResources(
+	fs afero.Fs, writer io.Writer, namespace, kubeConfigPath, kubectlPath string) error {
 	if d.artifactsDirectoryBase == "" {
 		return fmt.Errorf("$%s not set", testArtifactsDirectoryVarName)
 	}
@@ -66,7 +67,8 @@ func (d debugDeps) collectNamespacedResources(fs afero.Fs, writer io.Writer, nam
 		return fmt.Errorf("fetching API resource types failed: %v", err)
 	}
 
-	artifactsDirectory := path.Join(d.artifactsDirectoryBase, fmt.Sprintf("%s-%s", namespace, d.now().Format(time.RFC3339)))
+	artifactsDirectory := path.Join(
+		d.artifactsDirectoryBase, fmt.Sprintf("%s-%s", namespace, d.now().Format(time.RFC3339)))
 
 	err = fs.MkdirAll(artifactsDirectory, 0777)
 	if err != nil {
@@ -118,7 +120,8 @@ func (d debugDeps) collectNamespacedResources(fs afero.Fs, writer io.Writer, nam
 	return nil
 }
 
-func (d debugDeps) collectResources(fs afero.Fs, writer io.Writer, wg *sync.WaitGroup, namespace, fileName, resourcesNames,
+func (d debugDeps) collectResources(
+	fs afero.Fs, writer io.Writer, wg *sync.WaitGroup, namespace, fileName, resourcesNames,
 	directoryName, kubectlPath, kubeConfigPath string) {
 	defer wg.Done()
 

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -1,0 +1,239 @@
+package debug
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollectArtifacts_Disabled(t *testing.T) {
+	artifactsDirectoryBase = ""
+	sb := strings.Builder{}
+	CollectArtifacts(nil, &sb, "", "", "")
+	assert.Equal(t, sb.String(), "collection of resources for debugging failed: $TEST_ARTIFACTS_DIRECTORY not set\n")
+}
+
+type testStruct struct {
+	name            string
+	apiResourcesOut string
+	expectedOut     string
+	getOut          map[string]string
+	getErr          map[string]string
+	getExit         map[string]int
+	expectedDirs    []string
+	expectedFiles   map[string]string
+}
+
+func TestCollectArtifacts(t *testing.T) {
+	artifactsDirectoryBase = "/artifacts"
+	now = func() time.Time { return time.Time{} }
+	tests := []testStruct{
+		{
+			"zero api resources",
+			"",
+			"collecting namespaced resources for debugging...\n",
+			nil,
+			nil,
+			nil,
+			[]string{
+				"/artifacts",
+				"/artifacts/ns-0001-01-01T00:00:00Z",
+			},
+			nil,
+		},
+		{
+			"one resource no output",
+			"pods",
+			"collecting namespaced resources for debugging...\n",
+			map[string]string{
+				"pods": "",
+			},
+			nil,
+			nil,
+			[]string{
+				"/artifacts",
+				"/artifacts/ns-0001-01-01T00:00:00Z",
+			},
+			nil,
+		},
+		{
+			"one resource with output",
+			"pods",
+			"collecting namespaced resources for debugging...\n",
+			map[string]string{
+				"pods": "pod1\n",
+			},
+			nil,
+			nil,
+			[]string{
+				"/artifacts",
+				"/artifacts/ns-0001-01-01T00:00:00Z",
+			},
+			map[string]string{
+				"/artifacts/ns-0001-01-01T00:00:00Z/resources.yaml": "pod1\n",
+			},
+		},
+		{
+			"two resources of same group",
+			"pods\ngremlins\n",
+			"collecting namespaced resources for debugging...\npeekaboo\n",
+			map[string]string{
+				"gremlins,pods": "pod1\n",
+			},
+			map[string]string{
+				"gremlins,pods": "peekaboo\n",
+			},
+			nil,
+			[]string{
+				"/artifacts",
+				"/artifacts/ns-0001-01-01T00:00:00Z",
+			},
+			map[string]string{
+				"/artifacts/ns-0001-01-01T00:00:00Z/resources.yaml": "pod1\n",
+			},
+		},
+		{
+			"two groups of resources",
+			"pods\nservices\ninstances.kudo.dev\noperatorversions.kudo.dev\n",
+			"collecting namespaced resources for debugging...\n",
+			map[string]string{
+				"pods,services": "stuff\n",
+				"instances.kudo.dev,operatorversions.kudo.dev": "kudo\n",
+			},
+			nil,
+			nil,
+			[]string{
+				"/artifacts",
+				"/artifacts/ns-0001-01-01T00:00:00Z",
+			},
+			map[string]string{
+				"/artifacts/ns-0001-01-01T00:00:00Z/resources-kudo.dev.yaml": "kudo\n",
+				"/artifacts/ns-0001-01-01T00:00:00Z/resources.yaml":          "stuff\n",
+			},
+		},
+		{
+			"two groups of resources of which one fails",
+			"pods\ngremlins\ninstances.kudo.dev\noperatorversions.kudo.dev\n",
+			"collecting namespaced resources for debugging...\npeekaboo\nfetching gremlins,pods failed: exit status 1\n",
+			map[string]string{
+				"gremlins,pods": "peek...",
+				"instances.kudo.dev,operatorversions.kudo.dev": "kudo\n",
+			},
+			map[string]string{
+				"gremlins,pods": "peekaboo\n",
+			},
+			map[string]int{
+				"gremlins,pods": 1,
+			},
+			[]string{
+				"/artifacts",
+				"/artifacts/ns-0001-01-01T00:00:00Z",
+			},
+			map[string]string{
+				"/artifacts/ns-0001-01-01T00:00:00Z/resources-kudo.dev.yaml": "kudo\n",
+				"/artifacts/ns-0001-01-01T00:00:00Z/resources.yaml":          "peek...",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			sb := strings.Builder{}
+			execCommand = getExecCommand(t, test)
+
+			CollectArtifacts(fs, &sb, "ns", "kube.config", "kubectl")
+
+			assert.Equal(t, test.expectedOut, sb.String())
+			assert.NoError(t, afero.Walk(fs, "/", func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					if path == "/" {
+						return nil
+					}
+					assert.Contains(t, test.expectedDirs, path, "directory %q is not expected to exist", path)
+				} else {
+					_, ok := test.expectedFiles[path]
+					assert.True(t, ok, "file %q is not expected to exist", path)
+				}
+				return nil
+			}))
+			for file, expected := range test.expectedFiles {
+				exists, err := afero.Exists(fs, file)
+				assert.True(t, exists, "file %q should exist", file)
+				assert.NoError(t, err)
+				content, err := afero.ReadFile(fs, file)
+				if assert.NoError(t, err) {
+					assert.Equal(t, expected, string(content), "file %q has unexpected content", file)
+				}
+			}
+		})
+	}
+}
+
+func getExecCommand(t *testing.T, test testStruct) func(name string, arg ...string) *exec.Cmd {
+	return func(name string, arg ...string) *exec.Cmd {
+		assert.Equal(t, name, "kubectl")
+		assert.Equal(t, arg[0], "--kubeconfig")
+		assert.Equal(t, arg[1], "kube.config")
+		cmd := exec.Command(os.Args[0], append([]string{name}, arg...)...) // nolint:gosec
+
+		var (
+			stdOut string
+			stdErr string
+			exit   int
+		)
+
+		switch arg[2] {
+		case "api-resources":
+			stdOut = test.apiResourcesOut
+		case "get":
+			if declaredOut, ok := test.getOut[arg[3]]; ok {
+				stdOut = declaredOut
+			} else {
+				assert.FailNow(t, "internal test error", "GET %s does not have a declared output", arg[3])
+			}
+
+			if declaredErr, ok := test.getErr[arg[3]]; ok {
+				stdErr = declaredErr
+			}
+
+			if declaredExit, ok := test.getExit[arg[3]]; ok {
+				exit = declaredExit
+			}
+		default:
+			t.Fatalf("unexpected argument %q", arg[2])
+		}
+
+		cmd.Env = []string{"TEST_MODE=kubectl_wrapper", "STDOUT=" + stdOut, "STDERR=" + stdErr, "EXIT=" + strconv.Itoa(exit)}
+
+		return cmd
+	}
+}
+
+func kubectlWrapper() int {
+	fmt.Print(os.Getenv("STDOUT"))
+	fmt.Fprint(os.Stderr, os.Getenv("STDERR"))
+	exit, _ := strconv.Atoi(os.Getenv("EXIT"))
+
+	return exit
+}
+
+func TestMain(m *testing.M) {
+	switch os.Getenv("TEST_MODE") {
+	case "kubectl_wrapper":
+		os.Exit(kubectlWrapper())
+	default:
+		os.Exit(m.Run())
+	}
+}

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -17,9 +17,10 @@ import (
 
 func TestCollectArtifacts_Disabled(t *testing.T) {
 	sb := strings.Builder{}
-	debugDeps{
+	err := debugDeps{
 		artifactsDirectoryBase: "",
 	}.collectArtifacts(client.Client{}, nil, &sb, "", "")
+	assert.NoError(t, err)
 	assert.Equal(t, sb.String(), "collection of resources for debugging failed: $TEST_ARTIFACTS_DIRECTORY not set\n")
 }
 
@@ -155,7 +156,8 @@ func TestCollectArtifacts(t *testing.T) {
 			sb := strings.Builder{}
 			d.execCommand = getExecCommand(t, test)
 
-			d.collectArtifacts(client.Client{KubeConfigPath: "kube.config"}, fs, &sb, "ns", "kubectl")
+			err := d.collectArtifacts(client.Client{KubeConfigPath: "kube.config"}, fs, &sb, "ns", "kubectl")
+			assert.NoError(t, err)
 
 			assert.Equal(t, test.expectedOut, sb.String())
 			assert.NoError(t, afero.Walk(fs, "/", func(path string, info os.FileInfo, err error) error {

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -20,7 +20,7 @@ func TestCollectArtifacts_Disabled(t *testing.T) {
 	err := debugDeps{
 		artifactsDirectoryBase: "",
 	}.collectArtifacts(client.Client{}, nil, &sb, "", "")
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "$TEST_ARTIFACTS_DIRECTORY not set")
 	assert.Equal(t, sb.String(), "collection of resources for debugging failed: $TEST_ARTIFACTS_DIRECTORY not set\n")
 }
 

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -14,9 +14,10 @@ import (
 )
 
 func TestCollectArtifacts_Disabled(t *testing.T) {
-	artifactsDirectoryBase = ""
 	sb := strings.Builder{}
-	CollectArtifacts(nil, &sb, "", "", "")
+	debugDeps{
+		artifactsDirectoryBase: "",
+	}.collectArtifacts(nil, &sb, "", "", "")
 	assert.Equal(t, sb.String(), "collection of resources for debugging failed: $TEST_ARTIFACTS_DIRECTORY not set\n")
 }
 
@@ -32,8 +33,10 @@ type testStruct struct {
 }
 
 func TestCollectArtifacts(t *testing.T) {
-	artifactsDirectoryBase = "/artifacts"
-	now = func() time.Time { return time.Time{} }
+	d := debugDeps{
+		artifactsDirectoryBase: "/artifacts",
+		now:                    func() time.Time { return time.Time{} },
+	}
 	tests := []testStruct{
 		{
 			"zero api resources",
@@ -148,9 +151,9 @@ func TestCollectArtifacts(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			sb := strings.Builder{}
-			execCommand = getExecCommand(t, test)
+			d.execCommand = getExecCommand(t, test)
 
-			CollectArtifacts(fs, &sb, "ns", "kube.config", "kubectl")
+			d.collectArtifacts(fs, &sb, "ns", "kube.config", "kubectl")
 
 			assert.Equal(t, test.expectedOut, sb.String())
 			assert.NoError(t, afero.Walk(fs, "/", func(path string, info os.FileInfo, err error) error {

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -11,13 +11,15 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kudobuilder/test-tools/pkg/client"
 )
 
 func TestCollectArtifacts_Disabled(t *testing.T) {
 	sb := strings.Builder{}
 	debugDeps{
 		artifactsDirectoryBase: "",
-	}.collectArtifacts(nil, &sb, "", "", "")
+	}.collectArtifacts(client.Client{}, nil, &sb, "", "")
 	assert.Equal(t, sb.String(), "collection of resources for debugging failed: $TEST_ARTIFACTS_DIRECTORY not set\n")
 }
 
@@ -153,7 +155,7 @@ func TestCollectArtifacts(t *testing.T) {
 			sb := strings.Builder{}
 			d.execCommand = getExecCommand(t, test)
 
-			d.collectArtifacts(fs, &sb, "ns", "kube.config", "kubectl")
+			d.collectArtifacts(client.Client{KubeConfigPath: "kube.config"}, fs, &sb, "ns", "kubectl")
 
 			assert.Equal(t, test.expectedOut, sb.String())
 			assert.NoError(t, afero.Walk(fs, "/", func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
One new exported function: `CollectArtifacts` which gathers artifacts from a k8s cluster namespace which can help debugging failures. For now, these are YAML-format dumps of all resources in that namespace.

Invokes the `kubectl` binary where this is already implemented.

Eventually this implementation will probably be replaced with the diagnostics bundle ([KEP-22](https://github.com/kudobuilder/kudo/pulls?q=is%3Apr+is%3Aopen+label%3Akep%2F22)).