### PR TITLE
Introduce `Operator.UninstallWaitForDeletion`

### DIFF
--- a/pkg/kudo/operator.go
+++ b/pkg/kudo/operator.go
@@ -229,23 +229,29 @@ func (operator Operator) UninstallWaitForDeletion(timeout time.Duration) error {
 	}
 
 	if timeout != 0 {
-		kudoV1beta1 := operator.client.Kudo.KudoV1beta1()
+		kudoClient := operator.client.Kudo.KudoV1beta1()
 		i := operator.Instance
 		ov := operator.OperatorVersion
 		o := operator.Operator
-		timeoutSeconds := timeout.Round(time.Second).Milliseconds() / 1000
+		instanceTimeoutSec := timeout.Round(time.Second).Milliseconds() / 1000
 
-		err := waitForDeletion(kudoV1beta1.Instances(i.Namespace), i.ObjectMeta, timeoutSeconds)
+		const (
+			// after the instance is gone, these should in theory disappear quickly, since nothing should refer to them
+			operatorVersionTimeoutSec = 10
+			operatorTimeoutSec        = 10
+		)
+
+		err := waitForDeletion(kudoClient.Instances(i.Namespace), i.ObjectMeta, instanceTimeoutSec)
 		if err != nil {
 			return err
 		}
 
-		err = waitForDeletion(kudoV1beta1.OperatorVersions(ov.Namespace), ov.ObjectMeta, 10)
+		err = waitForDeletion(kudoClient.OperatorVersions(ov.Namespace), ov.ObjectMeta, operatorVersionTimeoutSec)
 		if err != nil {
 			return err
 		}
 
-		err = waitForDeletion(kudoV1beta1.Operators(o.Namespace), o.ObjectMeta, 10)
+		err = waitForDeletion(kudoClient.Operators(o.Namespace), o.ObjectMeta, operatorTimeoutSec)
 		if err != nil {
 			return err
 		}

--- a/pkg/kudo/operator.go
+++ b/pkg/kudo/operator.go
@@ -180,6 +180,9 @@ func (operator Operator) Uninstall() error {
 // UninstallWaitForDeletion is the same as Uninstall but
 // initiates a foreground deletion, and waits for the KUDO resources to disappear.
 // Waits up to timeout for the instance to be deleted, and up to 10 seconds for each of OperatorVersion and Operator.
+//
+// Note that in the past some issues which were not fully understood were observed when using foreground deletion on
+// Instances, see https://github.com/kudobuilder/kudo/issues/1071
 func (operator Operator) UninstallWaitForDeletion(timeout time.Duration) error {
 	if operator.client.Kudo == nil {
 		return fmt.Errorf("operator is not initialized")

--- a/pkg/kudo/operator.go
+++ b/pkg/kudo/operator.go
@@ -198,7 +198,7 @@ func (operator Operator) UninstallWaitForDeletion(timeout time.Duration) error {
 		Delete(operator.Instance.Name, &options)
 	if err != nil {
 		return fmt.Errorf(
-			"failed to delete Instance %s in namespace %s: %v",
+			"failed to delete Instance %s in namespace %s: %w",
 			operator.Instance.Name,
 			operator.Instance.Namespace,
 			err)
@@ -210,7 +210,7 @@ func (operator Operator) UninstallWaitForDeletion(timeout time.Duration) error {
 		Delete(operator.OperatorVersion.Name, &options)
 	if err != nil {
 		return fmt.Errorf(
-			"failed to delete OperatorVersion %s in namespace %s: %v",
+			"failed to delete OperatorVersion %s in namespace %s: %w",
 			operator.OperatorVersion.Name,
 			operator.OperatorVersion.Namespace,
 			err)
@@ -222,7 +222,7 @@ func (operator Operator) UninstallWaitForDeletion(timeout time.Duration) error {
 		Delete(operator.Operator.Name, &options)
 	if err != nil {
 		return fmt.Errorf(
-			"failed to delete Operator %s in namespace %s: %v",
+			"failed to delete Operator %s in namespace %s: %w",
 			operator.Operator.Name,
 			operator.Operator.Namespace,
 			err)


### PR DESCRIPTION
This is needed to work around a race/deadlock in statefulset controller tickled by now-faster kudo controller manager. See the story in https://github.com/mesosphere/kudo-cassandra-operator/pull/78 for details.

Also fix invalid format strings nearby.